### PR TITLE
Remove Extenject dependency

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -3,7 +3,6 @@
     "com.coffee.softmask-for-ugui": "https://github.com/mob-sakai/SoftMaskForUGUI.git",
     "com.coffee.ui-particle": "https://github.com/mob-sakai/ParticleEffectForUGUI.git",
     "com.jtfrom9.input-observable": "0.1.3",
-    "com.svermeulen.extenject": "https://github.com/svermeulen/Extenject.git?path=/UnityProject/Assets/Plugins/Zenject",
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.ai.navigation": "2.0.8",
     "com.unity.collab-proxy": "2.8.2",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -30,13 +30,6 @@
       "dependencies": {},
       "url": "https://package.openupm.com"
     },
-    "com.svermeulen.extenject": {
-      "version": "https://github.com/svermeulen/Extenject.git?path=/UnityProject/Assets/Plugins/Zenject",
-      "depth": 0,
-      "source": "git",
-      "dependencies": {},
-      "hash": "31f06cf81043f04301b1072ec81922b64149ea34"
-    },
     "com.unity.2d.sprite": {
       "version": "1.0.0",
       "depth": 0,


### PR DESCRIPTION
## Summary
- remove Extenject package from Unity manifest
- drop Extenject entry from packages-lock

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d5d1bcdc83339dafdf11a9a6edd0