### PR TITLE
Fix Unity UI assembly references for external tools

### DIFF
--- a/Assets/ZombieSoccer/Scripts/ExternalTools/Graphy - Ultimate Stats Monitor/Runtime/Tayx.Graphy.asmdef
+++ b/Assets/ZombieSoccer/Scripts/ExternalTools/Graphy - Ultimate Stats Monitor/Runtime/Tayx.Graphy.asmdef
@@ -1,7 +1,8 @@
 {
     "name": "Tayx.Graphy",
     "references": [
-        "GUID:75469ad4d38634e559750d17036d5f7c"
+        "GUID:75469ad4d38634e559750d17036d5f7c",
+        "UnityEngine.UI"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Assets/ZombieSoccer/Scripts/ExternalTools/Spine/Runtime/spine-unity.asmdef
+++ b/Assets/ZombieSoccer/Scripts/ExternalTools/Spine/Runtime/spine-unity.asmdef
@@ -1,4 +1,6 @@
-﻿{
-	"name": "spine-unity",
-	"references": []
+{
+        "name": "spine-unity",
+        "references": [
+            "UnityEngine.UI"
+        ]
 }


### PR DESCRIPTION
## Summary
- reference UnityEngine.UI in Graphy runtime asmdef
- reference UnityEngine.UI in Spine runtime asmdef

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f149713c83339eccdb9e1ee7f851